### PR TITLE
Only 400- and 500-level statuses should result in errors. 

### DIFF
--- a/SMWebRequest.m
+++ b/SMWebRequest.m
@@ -257,7 +257,7 @@ NSString *const SMErrorResponseKey = @"response";
     
     NSInteger status = [response isKindOfClass:[NSHTTPURLResponse class]] ? [(NSHTTPURLResponse *)response statusCode] : 200;
     
-    if (conn && response && (status < 200 || (status >= 300 && status != 304))) {
+    if (conn && response && status >= 400) {
         NSLog(@"Failed with HTTP status code %i while loading %@", (int)status, self);
         
         SMErrorResponse *error = [[[SMErrorResponse alloc] init] autorelease];


### PR DESCRIPTION
This prevents 100-level statuses and 300-level statuses from causing errors.
